### PR TITLE
Add possibility to mock static functions exported by var 

### DIFF
--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -234,12 +234,7 @@ func (g *generator) Generate(pkg *model.Package, pkgName string, outputPackagePa
 
 	// Only import reflect if it's used. We only use reflect in mocked methods
 	// so only import if any of the mocked interfaces have methods.
-	for _, intf := range pkg.Interfaces {
-		if len(intf.Methods) > 0 {
-			im["reflect"] = true
-			break
-		}
-	}
+	im["reflect"] = true
 
 	// Sort keys to make import alias generation predictable
 	sorted_paths := make([]string, len(im), len(im))

--- a/mockgen/model/model.go
+++ b/mockgen/model/model.go
@@ -30,6 +30,7 @@ const pkgPath = "github.com/golang/mock/mockgen/model"
 type Package struct {
 	Name       string
 	Interfaces []*Interface
+	Methods    []*Method
 	DotImports []string
 }
 
@@ -45,6 +46,9 @@ func (pkg *Package) Imports() map[string]bool {
 	im := make(map[string]bool)
 	for _, intf := range pkg.Interfaces {
 		intf.addImports(im)
+	}
+	for _, m := range pkg.Methods {
+		m.addImports(im)
 	}
 	return im
 }


### PR DESCRIPTION
package example:
```
package foobar

var Foo = foo
var Bar = bar

func foo() {}
func bar() int { return 42 }
```

common usage: 
```
package main

import "foobar"

func CheckAnswer() error {
  foobar.Foo()
  if answer := foobar.Bar(); answer != 42 {
    return fmt.Errorf("wrong answer %d", answer)
  }
  return nil
}
```

generate mock:
```
mockgen -mock_methods true -source foobar.go -destination mocked/foobar.go
```

mocked usage:
```
package main_test

import "foobar/mocked"

func TestCheckAnswer(t *testing.T) {
  ctrl := gomock.NewController(t)
  foobar := foobar_mock.NewMockfoobar_foobar(ctrl)
  defer ctrl.Finish()

  foobar.EXPECT().Bar().Return(-42)
  foobar.EXPECT().Foo()

  err := main.Run()
  if err != nil {
    t.Fail()
  }
}
```



		
